### PR TITLE
[Paperclip] docs: add contributing callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 :wave: *New to our project? Be sure to review the [OpenMRS 3 Frontend Developer Documentation](https://openmrs.atlassian.net/wiki/x/IABBHg). You may find the [Map of the Project](https://openmrs.atlassian.net/wiki/x/MgBuHg) especially helpful.* :teacher:
 
-> **Contributing:** See the [contributing guidelines](CONTRIBUTING.md) for how to get involved.
+> **Contributing:** See the [contributing guidelines](CONTRIBUTING.md) for how to get involved!
 
 ![Node.js CI](https://github.com/openmrs/openmrs-esm-patient-management/actions/workflows/ci.yml/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 :wave: *New to our project? Be sure to review the [OpenMRS 3 Frontend Developer Documentation](https://openmrs.atlassian.net/wiki/x/IABBHg). You may find the [Map of the Project](https://openmrs.atlassian.net/wiki/x/MgBuHg) especially helpful.* :teacher:
 
+> **Contributing:** See the [contributing guidelines](CONTRIBUTING.md) for how to get involved.
+
 ![Node.js CI](https://github.com/openmrs/openmrs-esm-patient-management/actions/workflows/ci.yml/badge.svg)
 
 # OpenMRS Patient Management


### PR DESCRIPTION
## Summary

- Adds a short contributing callout block to the top of `README.md`, linking to `CONTRIBUTING.md`
- Minimal change — no code affected

## Paperclip ticket

Implements [JAY-40](/JAY/issues/JAY-40) — _Open a small Test PR_

## Testing

README-only change; no test suite action required.

## Notes for reviewer

This is a test PR opened per Jaye's request in [JAY-40](/JAY/issues/JAY-40). The change is intentionally trivial.