### PR TITLE
(feat) O3-3299: Configurable name fields using NameTemplate in Patien…

### DIFF
--- a/__mocks__/patient-registration.mock.ts
+++ b/__mocks__/patient-registration.mock.ts
@@ -1,3 +1,62 @@
+export const mockedNameTemplate = {
+  displayName: null,
+  codeName: 'default',
+  country: null,
+  lines: [
+    [
+      {
+        isToken: 'IS_NOT_NAME_TOKEN' as const,
+        displayText: '',
+      },
+      {
+        isToken: 'IS_NAME_TOKEN' as const,
+        displayText: 'First Name',
+        codeName: 'givenName' as const,
+        displaySize: '40',
+      },
+    ],
+    [
+      {
+        isToken: 'IS_NOT_NAME_TOKEN' as const,
+        displayText: '',
+      },
+      {
+        isToken: 'IS_NAME_TOKEN' as const,
+        displayText: 'Middle Name',
+        codeName: 'middleName' as const,
+        displaySize: '40',
+      },
+    ],
+    [
+      {
+        isToken: 'IS_NOT_NAME_TOKEN' as const,
+        displayText: '',
+      },
+      {
+        isToken: 'IS_NAME_TOKEN' as const,
+        displayText: 'Family Name',
+        codeName: 'familyName' as const,
+        displaySize: '40',
+      },
+    ],
+  ],
+  lineByLineFormat: ['givenName', 'middleName', 'familyName'],
+  nameMappings: {
+    givenName: 'First Name',
+    middleName: 'Middle Name',
+    familyName: 'Family Name',
+  },
+  sizeMappings: {
+    givenName: '40',
+    middleName: '40',
+    familyName: '40',
+  },
+  elementDefaults: {},
+  elementRegex: null,
+  elementRegexFormats: null,
+  requiredElements: null,
+};
+
 export const mockedAddressTemplate = {
   displayName: null,
   codeName: 'default',

--- a/packages/esm-patient-registration-app/src/offline.resources.ts
+++ b/packages/esm-patient-registration-app/src/offline.resources.ts
@@ -12,6 +12,7 @@ import type {
   ConceptResponse,
   FetchedPatientIdentifierType,
   IdentifierSourceAutoGenerationOption,
+  NameTemplate,
   PatientIdentifierType,
   PersonAttributeTypeResponse,
   RelationshipTypesResponse,
@@ -21,6 +22,7 @@ import type { FieldDefinition } from './config-schema';
 
 export interface Resources {
   addressTemplate: AddressTemplate;
+  nameTemplate: NameTemplate;
   currentSession: Session;
   relationshipTypes: RelationshipTypesResponse;
   identifierTypes: Array<PatientIdentifierType>;
@@ -33,6 +35,11 @@ export async function fetchCurrentSession(): Promise<Session> {
 
 export async function fetchAddressTemplate() {
   const { data } = await cacheAndFetch<AddressTemplate>(`${restBaseUrl}/addresstemplate`);
+  return data;
+}
+
+export async function fetchNameTemplate() {
+  const { data } = await cacheAndFetch<NameTemplate>(`${restBaseUrl}/nametemplate/layout.name.format`);
   return data;
 }
 

--- a/packages/esm-patient-registration-app/src/offline.ts
+++ b/packages/esm-patient-registration-app/src/offline.ts
@@ -14,6 +14,7 @@ import {
   fetchAllFieldDefinitionTypes,
   fetchAllRelationshipTypes,
   fetchCurrentSession,
+  fetchNameTemplate,
   fetchPatientIdentifierTypesWithSources,
 } from './offline.resources';
 import { FormManager } from './patient-registration/form-manager';
@@ -67,6 +68,7 @@ async function precacheStaticAssets() {
   await Promise.all([
     fetchCurrentSession(),
     fetchAddressTemplate(),
+    fetchNameTemplate(),
     fetchAllRelationshipTypes(),
     fetchAllFieldDefinitionTypes(),
     fetchPatientIdentifierTypesWithSources(),

--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-field.component.tsx
@@ -9,7 +9,7 @@ import {
   usePatientRegistrationContext,
 } from '../../patient-registration-context';
 import { ResourcesContextProvider, useResourcesContext } from '../../../resources-context';
-import { type AddressTemplate } from '../../patient-registration.types';
+import { type AddressTemplate, type NameTemplate } from '../../patient-registration.types';
 import { Input } from '../../input/basic-input/input/input.component';
 import AddressHierarchyLevels from './address-hierarchy-levels.component';
 import AddressSearchComponent from './address-search.component';
@@ -158,6 +158,7 @@ const AddressComponentContainer = ({ children }) => {
     <ResourcesContextProvider
       value={{
         addressTemplate: {} as AddressTemplate,
+        nameTemplate: {} as NameTemplate,
         currentSession: {} as Session,
         identifierTypes: [],
         relationshipTypes: { results: [] },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/address/address-hierarchy.test.tsx
@@ -4,7 +4,7 @@ import { Formik, Form } from 'formik';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { mockedAddressTemplate, mockedOrderedFields, mockOpenmrsId, mockPatient, mockSession } from '__mocks__';
 import { renderWithContext } from 'tools';
-import { type AddressTemplate } from '../../patient-registration.types';
+import { type AddressTemplate, type NameTemplate } from '../../patient-registration.types';
 import { type RegistrationConfig, esmPatientRegistrationSchema } from '../../../config-schema';
 import { type Resources } from '../../../offline.resources';
 import {
@@ -20,6 +20,7 @@ const mockUseOrderedAddressHierarchyLevels = jest.mocked(useOrderedAddressHierar
 
 const mockResourcesContextValue = {
   addressTemplate: {} as AddressTemplate,
+  nameTemplate: {} as NameTemplate,
   currentSession: mockSession.data,
   identifierTypes: [],
   relationshipTypes: { results: [] },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { reportError, useConfig } from '@openmrs/esm-framework';
+import { reportError, useConfig, useFeatureFlag } from '@openmrs/esm-framework';
 import { builtInFields, type RegistrationConfig } from '../../config-schema';
 import { AddressComponent } from './address/address-field.component';
 import { CauseOfDeathField } from './cause-of-death/cause-of-death.component';
@@ -9,6 +9,7 @@ import { DobField } from './dob/dob.component';
 import { GenderField } from './gender/gender-field.component';
 import { Identifiers } from './id/id-field.component';
 import { NameField } from './name/name-field.component';
+import { NameFieldWithTemplate } from './name/name-field-template-layout.component';
 import { PhoneField } from './phone/phone-field.component';
 
 export interface FieldProps {
@@ -17,6 +18,8 @@ export interface FieldProps {
 
 export function Field({ name }: FieldProps) {
   const config = useConfig<RegistrationConfig>();
+  const isNameTemplateLayoutEnabled = useFeatureFlag('name-template-layout');
+
   if (
     !(builtInFields as ReadonlyArray<string>).includes(name) &&
     !config.fieldDefinitions.some((def) => def.id === name)
@@ -32,7 +35,7 @@ export function Field({ name }: FieldProps) {
 
   switch (name) {
     case 'name':
-      return <NameField />;
+      return isNameTemplateLayoutEnabled ? <NameFieldWithTemplate /> : <NameField />;
     case 'gender':
       return <GenderField />;
     case 'dob':

--- a/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/field.test.tsx
@@ -5,7 +5,8 @@ import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
 import { Field } from './field.component';
 import { esmPatientRegistrationSchema, type RegistrationConfig } from '../../config-schema';
 import { type Resources } from '../../offline.resources';
-import type { AddressTemplate, FormValues } from '../patient-registration.types';
+import type { AddressTemplate, FormValues, NameTemplate } from '../patient-registration.types';
+import { mockedNameTemplate } from '__mocks__';
 import { PatientRegistrationContextProvider } from '../patient-registration-context';
 import { ResourcesContextProvider } from '../../resources-context';
 import { renderWithContext } from 'tools';
@@ -85,6 +86,7 @@ const mockIdentifierTypes = [
 
 const mockResourcesContextValue: Resources = {
   addressTemplate: predefinedAddressTemplate as unknown as AddressTemplate,
+  nameTemplate: mockedNameTemplate as unknown as NameTemplate,
   currentSession: {
     authenticated: true,
     sessionId: 'JSESSION',

--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/id-field.test.tsx
@@ -3,7 +3,7 @@ import { Form, Formik } from 'formik';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
-import { type AddressTemplate, type IdentifierSource } from '../../patient-registration.types';
+import { type AddressTemplate, type IdentifierSource, type NameTemplate } from '../../patient-registration.types';
 import { mockIdentifierTypes, mockOpenmrsId, mockPatient, mockSession } from '__mocks__';
 import { renderWithContext } from 'tools';
 import { esmPatientRegistrationSchema, type RegistrationConfig } from '../../../config-schema';
@@ -19,6 +19,7 @@ const mockUseConfig = jest.mocked(useConfig<RegistrationConfig>);
 
 const mockResourcesContextValue = {
   addressTemplate: null as unknown as AddressTemplate,
+  nameTemplate: null as unknown as NameTemplate,
   currentSession: mockSession.data,
   identifierTypes: [],
   relationshipTypes: { results: [] },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/id/identifier-selection-overlay.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/id/identifier-selection-overlay.test.tsx
@@ -12,7 +12,12 @@ import {
 } from '../../patient-registration-context';
 import { ResourcesContextProvider } from '../../../resources-context';
 import PatientIdentifierOverlay from './identifier-selection-overlay.component';
-import type { AddressTemplate, FormValues, PatientIdentifierType } from '../../patient-registration.types';
+import type {
+  AddressTemplate,
+  FormValues,
+  NameTemplate,
+  PatientIdentifierType,
+} from '../../patient-registration.types';
 import type { Resources } from '../../../offline.resources';
 
 const mockUseConfig = jest.mocked(useConfig<RegistrationConfig>);
@@ -74,6 +79,7 @@ const mockIdentifierTypes: PatientIdentifierType[] = [
 
 const mockResourcesContextValue: Resources = {
   addressTemplate: {} as AddressTemplate,
+  nameTemplate: {} as NameTemplate,
   currentSession: mockSession.data,
   identifierTypes: mockIdentifierTypes,
   relationshipTypes: { results: [] },

--- a/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field-template-layout.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field-template-layout.component.tsx
@@ -1,0 +1,178 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ContentSwitcher, SkeletonText, Switch } from '@carbon/react';
+import { useField } from 'formik';
+import { useConfig } from '@openmrs/esm-framework';
+import { type RegistrationConfig } from '../../../config-schema';
+import { useResourcesContext } from '../../../resources-context';
+import { Input } from '../../input/basic-input/input/input.component';
+import { usePatientRegistrationContext } from '../../patient-registration-context';
+import { type NameProperties, type NameTemplate } from '../../patient-registration.types';
+import { PhotoComponent } from '../photo/photo-field.component';
+import styles from '../field.scss';
+
+export const unidentifiedPatientAttributeTypeUuid = '8b56eac7-5c76-4b9c-8c6f-1deab8d3fc47';
+
+const containsNoNumbers = /^([^0-9]*)$/;
+
+function checkNoNumbers(value: string) {
+  if (!containsNoNumbers.test(value)) {
+    return 'numberInNameDubious';
+  }
+  return undefined;
+}
+
+function getLayoutFields(nameTemplate: NameTemplate, reverseFieldOrder = false) {
+  const allFields = nameTemplate?.lines?.flat() ?? [];
+  const fields = allFields.filter(({ isToken }) => isToken === 'IS_NAME_TOKEN');
+  return reverseFieldOrder ? [...fields].reverse() : fields;
+}
+
+function getRequiredFields(nameTemplate: NameTemplate, ...alwaysRequired: NameProperties[]) {
+  const templateRequired = nameTemplate?.requiredElements ?? [];
+  return new Set<NameProperties>([...alwaysRequired, ...templateRequired]);
+}
+
+export const NameFieldWithTemplate: React.FC = () => {
+  const { t } = useTranslation();
+  const { setFieldValue, setFieldTouched } = usePatientRegistrationContext();
+  const {
+    fieldConfigurations: {
+      name: {
+        displayCapturePhoto,
+        allowUnidentifiedPatients,
+        defaultUnknownGivenName,
+        defaultUnknownFamilyName,
+        displayReverseFieldOrder,
+      },
+    },
+  } = useConfig<RegistrationConfig>();
+
+  const { nameTemplate } = useResourcesContext();
+
+  const defaultNameLayout = useMemo(() => {
+    const fields = [
+      { id: 'givenName', name: 'givenName', label: t('givenNameLabelText', 'First Name'), required: true },
+      { id: 'middleName', name: 'middleName', label: t('middleNameLabelText', 'Middle Name'), required: false },
+      { id: 'familyName', name: 'familyName', label: t('familyNameLabelText', 'Family Name'), required: true },
+    ];
+    return displayReverseFieldOrder ? [...fields].reverse() : fields;
+  }, [t, displayReverseFieldOrder]);
+
+  const nameLayout = useMemo(() => {
+    if (!nameTemplate?.lines) {
+      return defaultNameLayout;
+    }
+    const fields = getLayoutFields(nameTemplate, displayReverseFieldOrder);
+    // givenName and familyName are always required by the patient API, independent of the template.
+    const requiredFields = getRequiredFields(nameTemplate, 'givenName', 'familyName');
+    return fields.map(({ displayText, codeName }) => ({
+      id: codeName,
+      name: codeName,
+      label: displayText,
+      required: requiredFields.has(codeName),
+    }));
+  }, [nameTemplate, defaultNameLayout, displayReverseFieldOrder]);
+
+  const clearNameFieldValues = useCallback(() => {
+    nameLayout.forEach((field) => {
+      setFieldValue(field.name, '');
+    });
+  }, [nameLayout, setFieldValue]);
+
+  const setDefaultNameFieldValues = useCallback(() => {
+    if (nameTemplate?.elementDefaults) {
+      Object.entries(nameTemplate.elementDefaults).forEach(([name, defaultValue]) => {
+        setFieldValue(name, defaultValue);
+      });
+    }
+  }, [nameTemplate, setFieldValue]);
+
+  const setUnknownNameFieldValues = useCallback(() => {
+    setFieldValue('givenName', defaultUnknownGivenName);
+    setFieldValue('familyName', defaultUnknownFamilyName);
+  }, [setFieldValue, defaultUnknownGivenName, defaultUnknownFamilyName]);
+
+  const touchNameFields = useCallback(() => {
+    nameLayout.forEach((field) => {
+      setFieldTouched(field.name, true);
+    });
+  }, [nameLayout, setFieldTouched]);
+
+  useEffect(() => {
+    setDefaultNameFieldValues();
+  }, [setDefaultNameFieldValues]);
+
+  const [{ value: isPatientUnknownValue }, , { setValue: setUnknownPatient }] = useField<string>(
+    `attributes.${unidentifiedPatientAttributeTypeUuid}`,
+  );
+
+  const isPatientUnknown = isPatientUnknownValue === 'true';
+
+  const toggleNameKnown = (e) => {
+    clearNameFieldValues();
+    setDefaultNameFieldValues();
+    if (e.name === 'known') {
+      setUnknownPatient('false');
+    } else {
+      setUnknownNameFieldValues();
+      setUnknownPatient('true');
+    }
+    touchNameFields();
+    setFieldTouched(`attributes.${unidentifiedPatientAttributeTypeUuid}`, true, false);
+  };
+
+  if (nameTemplate && !Object.keys(nameTemplate).length) {
+    return (
+      <NameComponentContainer>
+        <div role="progressbar" aria-label={t('loading', 'Loading')}>
+          <SkeletonText />
+        </div>
+      </NameComponentContainer>
+    );
+  }
+
+  return (
+    <NameComponentContainer>
+      {displayCapturePhoto && <PhotoComponent />}
+      <div className={styles.nameField}>
+        {(allowUnidentifiedPatients || isPatientUnknown) && (
+          <>
+            <div className={styles.dobContentSwitcherLabel}>
+              <span className={styles.label01}>{t('patientNameKnown', "Patient's Name is Known?")}</span>
+            </div>
+            <ContentSwitcher
+              className={styles.contentSwitcher}
+              size="md"
+              selectedIndex={isPatientUnknown ? 1 : 0}
+              onChange={toggleNameKnown}>
+              <Switch name="known">{t('yes', 'Yes')}</Switch>
+              <Switch name="unknown">{t('no', 'No')}</Switch>
+            </ContentSwitcher>
+          </>
+        )}
+        {!isPatientUnknown &&
+          nameLayout.map((field, index) => (
+            <Input
+              key={`name_input_${field.name ?? index}`}
+              id={`name.${field.name}`}
+              name={field.name}
+              labelText={field.label}
+              checkWarning={checkNoNumbers}
+              required={field.required}
+            />
+          ))}
+      </div>
+    </NameComponentContainer>
+  );
+};
+
+const NameComponentContainer = ({ children }: { children: React.ReactNode }) => {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <h4 className={styles.productiveHeading02Light}>{t('fullNameLabelText', 'Full Name')}</h4>
+      <div className={styles.grid}>{children}</div>
+    </div>
+  );
+};

--- a/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/name/name-field.component.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ContentSwitcher, Switch } from '@carbon/react';
 import { useField } from 'formik';
-import { ExtensionSlot, useConfig } from '@openmrs/esm-framework';
+import { useConfig } from '@openmrs/esm-framework';
 import { type RegistrationConfig } from '../../../config-schema';
 import { usePatientRegistrationContext } from '../../patient-registration-context';
 import { Input } from '../../input/basic-input/input/input.component';
+import { PhotoComponent } from '../photo/photo-field.component';
 import styles from '../field.scss';
 
 export const unidentifiedPatientAttributeTypeUuid = '8b56eac7-5c76-4b9c-8c6f-1deab8d3fc47';
@@ -21,7 +22,7 @@ function checkNumber(value: string) {
 
 export const NameField = () => {
   const { t } = useTranslation();
-  const { setCapturePhotoProps, currentPhoto, setFieldValue, setFieldTouched } = usePatientRegistrationContext();
+  const { setFieldValue, setFieldTouched } = usePatientRegistrationContext();
 
   const {
     fieldConfigurations: {
@@ -41,19 +42,6 @@ export const NameField = () => {
   );
 
   const isPatientUnknown = isPatientUnknownValue === 'true';
-
-  const onCapturePhoto = useCallback(
-    (dataUri: string, photoDateTime: string) => {
-      if (setCapturePhotoProps) {
-        setCapturePhotoProps({
-          imageData: dataUri,
-          dateTime: photoDateTime,
-        });
-        setFieldTouched('photo', true, false);
-      }
-    },
-    [setCapturePhotoProps, setFieldTouched],
-  );
 
   const toggleNameKnown = (e) => {
     if (e.name === 'known') {
@@ -103,13 +91,7 @@ export const NameField = () => {
     <div>
       <h4 className={styles.productiveHeading02Light}>{t('fullNameLabelText', 'Full Name')}</h4>
       <div className={styles.grid}>
-        {displayCapturePhoto && (
-          <ExtensionSlot
-            className={styles.photoExtension}
-            name="capture-patient-photo-slot"
-            state={{ onCapturePhoto, initialState: currentPhoto }}
-          />
-        )}
+        {displayCapturePhoto && <PhotoComponent />}
 
         <div className={styles.nameField}>
           {(allowUnidentifiedPatients || isPatientUnknown) && (

--- a/packages/esm-patient-registration-app/src/patient-registration/field/photo/photo-field.component.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/field/photo/photo-field.component.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from 'react';
+import { ExtensionSlot } from '@openmrs/esm-framework';
+import { usePatientRegistrationContext } from '../../patient-registration-context';
+import styles from '../field.scss';
+
+export const PhotoComponent = () => {
+  const { setCapturePhotoProps, currentPhoto, setFieldTouched } = usePatientRegistrationContext();
+
+  const onCapturePhoto = useCallback(
+    (dataUri: string, photoDateTime: string) => {
+      if (setCapturePhotoProps) {
+        setCapturePhotoProps({
+          imageData: dataUri,
+          dateTime: photoDateTime,
+        });
+        setFieldTouched('photo', true, false);
+      }
+    },
+    [setCapturePhotoProps, setFieldTouched],
+  );
+
+  return (
+    <ExtensionSlot
+      className={styles.photoExtension}
+      name="capture-patient-photo-slot"
+      state={{ onCapturePhoto, initialState: currentPhoto }}
+    />
+  );
+};

--- a/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/input/custom-input/identifier/identifier-input.test.tsx
@@ -15,6 +15,7 @@ import type {
   AddressTemplate,
   FormValues,
   IdentifierSource,
+  NameTemplate,
   PatientIdentifierValue,
 } from '../../../patient-registration.types';
 import IdentifierInput from './identifier-input.component';
@@ -63,6 +64,7 @@ const mockIdentifierTypes = [
 
 const mockResourcesContextValue: Resources = {
   addressTemplate: {} as AddressTemplate,
+  nameTemplate: {} as NameTemplate,
   currentSession: {
     authenticated: true,
     sessionId: 'JSESSION',

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.test.tsx
@@ -9,8 +9,8 @@ import {
   useConfig,
   usePatient,
 } from '@openmrs/esm-framework';
-import type { AddressTemplate, Encounter, FormValues } from './patient-registration.types';
-import { mockedAddressTemplate } from '__mocks__';
+import type { AddressTemplate, Encounter, FormValues, NameTemplate } from './patient-registration.types';
+import { mockedAddressTemplate, mockedNameTemplate } from '__mocks__';
 import { mockPatient, renderWithContext } from 'tools';
 import { saveEncounter, savePatient } from './patient-registration.resource';
 import { esmPatientRegistrationSchema, type RegistrationConfig } from '../config-schema';
@@ -137,6 +137,7 @@ jest.mock('./patient-registration-hooks', () => {
 
 const mockResourcesContextValue = {
   addressTemplate: mockedAddressTemplate as AddressTemplate,
+  nameTemplate: mockedNameTemplate as unknown as NameTemplate,
   currentSession: {
     authenticated: true,
     sessionId: 'JSESSION',

--- a/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.ts
+++ b/packages/esm-patient-registration-app/src/patient-registration/patient-registration.types.ts
@@ -309,3 +309,36 @@ export interface AddressTemplate {
   elementRegexFormats: ExtensibleAddressProperties;
   requiredElements: Array<AddressProperties> | null;
 }
+
+export type NameProperties =
+  | 'prefix'
+  | 'givenName'
+  | 'middleName'
+  | 'familyNamePrefix'
+  | 'familyName'
+  | 'familyName2'
+  | 'familyNameSuffix'
+  | 'degree';
+
+export type ExtensibleNameProperties = { [p in NameProperties]?: string } | null;
+
+export interface NameTemplate {
+  displayName: string | null;
+  codeName: string | null;
+  country: string | null;
+  lines: Array<
+    Array<{
+      isToken: 'IS_NOT_NAME_TOKEN' | 'IS_NAME_TOKEN';
+      displayText: string;
+      codeName?: NameProperties;
+      displaySize?: string;
+    }>
+  > | null;
+  lineByLineFormat: Array<string> | null;
+  nameMappings: ExtensibleNameProperties;
+  sizeMappings: ExtensibleNameProperties;
+  elementDefaults: ExtensibleNameProperties;
+  elementRegex: ExtensibleNameProperties;
+  elementRegexFormats: ExtensibleNameProperties;
+  requiredElements: Array<NameProperties> | null;
+}

--- a/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/demographics/demographics-section.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Formik, Form } from 'formik';
-import { getDefaultsFromConfigSchema, useConfig } from '@openmrs/esm-framework';
+import { getDefaultsFromConfigSchema, useConfig, useFeatureFlag } from '@openmrs/esm-framework';
 import { initialFormValues } from '../../patient-registration.component';
 import { type FormValues } from '../../patient-registration.types';
 import { DemographicsSection } from './demographics-section.component';
@@ -9,6 +9,7 @@ import { PatientRegistrationContextProvider } from '../../patient-registration-c
 import { type RegistrationConfig, esmPatientRegistrationSchema } from '../../../config-schema';
 
 const mockUseConfig = jest.mocked(useConfig<RegistrationConfig>);
+const mockUseFeatureFlag = jest.mocked(useFeatureFlag);
 
 /**
  * Helper to render DemographicsSection with Formik for state-dependent tests.
@@ -59,6 +60,7 @@ function renderDemographicsSectionWithFormik(
 
 describe('Demographics section', () => {
   beforeEach(() => {
+    mockUseFeatureFlag.mockImplementation((flagName) => (flagName === 'name-template-layout' ? false : false));
     mockUseConfig.mockReturnValue({
       ...getDefaultsFromConfigSchema(esmPatientRegistrationSchema),
       fieldConfigurations: {

--- a/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.test.tsx
+++ b/packages/esm-patient-registration-app/src/patient-registration/section/patient-relationships/relationships-section.test.tsx
@@ -95,6 +95,7 @@ describe('RelationshipsSection', () => {
     it('renders a loader when relationshipTypes are not available', () => {
       const mockResourcesContextValue = {
         addressTemplate: null,
+        nameTemplate: null,
         currentSession: {
           authenticated: true,
           sessionId: 'JSESSION',
@@ -116,6 +117,7 @@ describe('RelationshipsSection', () => {
     it('renders the relationships section when relationshipTypes are available', () => {
       const mockResourcesContextValue = {
         addressTemplate: null,
+        nameTemplate: null,
         currentSession: {
           authenticated: true,
           sessionId: 'JSESSION',
@@ -134,6 +136,7 @@ describe('RelationshipsSection', () => {
     it('renders existing relationships', () => {
       const mockResourcesContextValue = {
         addressTemplate: null,
+        nameTemplate: null,
         currentSession: {
           authenticated: true,
           sessionId: 'JSESSION',
@@ -166,6 +169,7 @@ describe('RelationshipsSection', () => {
     it('renders relationship type options', () => {
       const mockResourcesContextValue = {
         addressTemplate: null,
+        nameTemplate: null,
         currentSession: {
           authenticated: true,
           sessionId: 'JSESSION',
@@ -193,6 +197,7 @@ describe('RelationshipsSection', () => {
       const user = userEvent.setup();
       const mockResourcesContextValue = {
         addressTemplate: null,
+        nameTemplate: null,
         currentSession: {
           authenticated: true,
           sessionId: 'JSESSION',
@@ -227,6 +232,7 @@ describe('RelationshipsSection', () => {
       const user = userEvent.setup();
       const mockResourcesContextValue = {
         addressTemplate: null,
+        nameTemplate: null,
         currentSession: {
           authenticated: true,
           sessionId: 'JSESSION',
@@ -263,6 +269,7 @@ describe('RelationshipsSection', () => {
       const user = userEvent.setup();
       const mockResourcesContextValue = {
         addressTemplate: null,
+        nameTemplate: null,
         currentSession: {
           authenticated: true,
           sessionId: 'JSESSION',

--- a/packages/esm-patient-registration-app/src/root.component.tsx
+++ b/packages/esm-patient-registration-app/src/root.component.tsx
@@ -7,6 +7,7 @@ import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import {
   fetchAddressTemplate,
   fetchAllRelationshipTypes,
+  fetchNameTemplate,
   fetchPatientIdentifierTypesWithSources,
 } from './offline.resources';
 import { ResourcesContextProvider } from './resources-context';
@@ -18,6 +19,7 @@ export default function Root() {
   const isOnline = useConnectivity();
   const currentSession = useSession();
   const { data: addressTemplate } = useSWRImmutable('patientRegistrationAddressTemplate', fetchAddressTemplate);
+  const { data: nameTemplate } = useSWRImmutable('patientRegistrationNameTemplate', fetchNameTemplate);
   const { data: relationshipTypes } = useSWRImmutable(
     'patientRegistrationRelationshipTypes',
     fetchAllRelationshipTypes,
@@ -37,6 +39,7 @@ export default function Root() {
         <ResourcesContextProvider
           value={{
             addressTemplate,
+            nameTemplate,
             relationshipTypes,
             identifierTypes,
             currentSession,

--- a/packages/esm-patient-registration-app/src/routes.json
+++ b/packages/esm-patient-registration-app/src/routes.json
@@ -3,6 +3,16 @@
   "backendDependencies": {
     "webservices.rest": ">=2.2.0"
   },
+  "optionalBackendDependencies": {
+    "webservices.rest": {
+      "version": "^2.49.0",
+      "feature": {
+        "flagName": "name-template-layout",
+        "label": "Patient Registration Name Layout",
+        "description": "Render the patient registration name fields according to the configured OpenMRS name template, enabling locale-specific field sets and order."
+      }
+    }
+  },
   "pages": [
     {
       "component": "root",


### PR DESCRIPTION
* "Claude PR Assistant workflow"

* "Claude Code Review workflow"## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
* "Claude PR Assistant workflow"

* "Claude Code Review workflow"…t Registration

Adds an opt-in flow that renders the patient registration name fields from the
OpenMRS name template (backed by /ws/rest/v1/nametemplate/layout.name.format)
so implementations can provide locale-appropriate field sets and ordering.

- New NameFieldWithTemplate component driven by the fetched NameTemplate
- Feature-flag the new layout via optionalBackendDependencies in routes.json,
  keyed to webservices.rest ^2.49.0 which exposes the nametemplate endpoint
- Extract capture-patient-photo-slot into a reusable PhotoComponent shared
  between the legacy and template-driven name fields
- Add NameTemplate type, resource fetcher, root + offline precache wiring,
  and extend Resources context consumers and tests accordingly

Co-Authored-By: Paperclip <noreply@paperclip.ing>